### PR TITLE
Add NuttyOS landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NuttyOS · A Windows-inspired web experience</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="bg-grid"></div>
+  <header class="hero">
+    <div class="hero__content">
+      <p class="eyebrow">NuttyOS 11 preview</p>
+      <h1>Windows comfort. Nutty speed.</h1>
+      <p class="lede">Meet NuttyOS, a playful desktop that blends the familiarity of Windows with a faster, friendlier web-first experience.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="#download">Download ISO</a>
+        <a class="btn btn-ghost" href="#features">Explore features</a>
+      </div>
+    </div>
+    <div class="hero__window" role="presentation">
+      <div class="window">
+        <div class="window__topbar">
+          <div class="window__traffic">
+            <span class="dot dot--red"></span>
+            <span class="dot dot--yellow"></span>
+            <span class="dot dot--green"></span>
+          </div>
+          <div class="window__title">File Explorer · NuttyOS</div>
+        </div>
+        <div class="window__body">
+          <div class="desktop">
+            <div class="desktop__tile">
+              <span class="emoji" aria-hidden="true">🪟</span>
+              <p>System</p>
+            </div>
+            <div class="desktop__tile">
+              <span class="emoji" aria-hidden="true">📂</span>
+              <p>Files</p>
+            </div>
+            <div class="desktop__tile">
+              <span class="emoji" aria-hidden="true">🌐</span>
+              <p>Browser</p>
+            </div>
+            <div class="desktop__tile">
+              <span class="emoji" aria-hidden="true">🎮</span>
+              <p>Play</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="features" class="panel">
+      <div class="panel__header">
+        <h2>Why NuttyOS feels like home</h2>
+        <p>Classic shortcuts, centered taskbar, and delightful micro-interactions keep you comfortable while the system stays fast.</p>
+      </div>
+      <div class="grid">
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">⚡</div>
+          <h3>Fast boot</h3>
+          <p>Optimized startup and a lean kernel bring you to the desktop in seconds.</p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">🪟</div>
+          <h3>Window snap</h3>
+          <p>Snap Assist keeps windows tidy with intuitive keyboard shortcuts.</p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">🔐</div>
+          <h3>Secure core</h3>
+          <p>Sandboxed apps and encrypted storage help keep your workspace safe.</p>
+        </article>
+        <article class="card">
+          <div class="card__icon" aria-hidden="true">🎨</div>
+          <h3>Live themes</h3>
+          <p>Dynamic wallpapers and light/dark modes that adapt to your environment.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="panel panel--alt">
+      <div class="panel__header">
+        <h2>Start menu that just works</h2>
+        <p>Pin favorites, search instantly, and jump back into your most recent work without friction.</p>
+      </div>
+      <div class="startmenu">
+        <div class="startmenu__left">
+          <h4>Pinned</h4>
+          <ul class="startmenu__grid">
+            <li>Browser</li>
+            <li>Mail</li>
+            <li>Files</li>
+            <li>Studio</li>
+            <li>Play</li>
+            <li>Store</li>
+          </ul>
+        </div>
+        <div class="startmenu__right">
+          <h4>Recommended</h4>
+          <div class="recents">
+            <div>
+              <p class="label">Design Board.fig</p>
+              <p class="muted">Edited 2h ago</p>
+            </div>
+            <div>
+              <p class="label">NuttyOS Release Notes</p>
+              <p class="muted">Yesterday</p>
+            </div>
+            <div>
+              <p class="label">Terminal logs</p>
+              <p class="muted">This week</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="download" class="panel">
+      <div class="panel__header">
+        <h2>Ready to try NuttyOS?</h2>
+        <p>Grab the ISO, flash it to a USB drive, and boot into your new desktop in under ten minutes.</p>
+      </div>
+      <div class="download">
+        <div>
+          <p class="muted">NuttyOS 11 · Build 2407</p>
+          <p class="label">Includes desktop shell, core apps, and developer tools.</p>
+        </div>
+        <a class="btn btn-primary" href="#">Download</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer__brand">NuttyOS</div>
+    <p class="muted">Windows-inspired, web-powered. Crafted by the Nutty team.</p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,322 @@
+:root {
+  --bg: #0c0f19;
+  --panel: rgba(255, 255, 255, 0.04);
+  --panel-alt: rgba(255, 255, 255, 0.07);
+  --accent: #5ea3ff;
+  --accent-2: #a19dff;
+  --text: #eef2ff;
+  --muted: #9aa3b5;
+  --card: rgba(255, 255, 255, 0.06);
+  --shadow: 0 20px 70px rgba(0, 0, 0, 0.35);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: radial-gradient(circle at 20% 20%, rgba(94, 163, 255, 0.18), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(161, 157, 255, 0.25), transparent 25%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.6;
+  padding: 48px 6vw 96px;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.bg-grid {
+  position: fixed;
+  inset: 0;
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 120px 120px;
+  mask-image: radial-gradient(circle at center, black 0%, black 60%, transparent 100%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  margin-bottom: 12px;
+}
+
+.hero__content .lede {
+  color: var(--muted);
+  max-width: 560px;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 10px;
+}
+
+.cta-row {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.btn {
+  padding: 12px 18px;
+  border-radius: 12px;
+  font-weight: 700;
+  border: 1px solid transparent;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0b0e15;
+  box-shadow: var(--shadow);
+}
+
+.btn-ghost {
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.hero__window {
+  display: flex;
+  justify-content: center;
+}
+
+.window {
+  background: rgba(16, 21, 35, 0.9);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow);
+  width: min(540px, 100%);
+  overflow: hidden;
+}
+
+.window__topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.04), rgba(94, 163, 255, 0.08));
+}
+
+.window__traffic {
+  display: flex;
+  gap: 8px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot--red { background: #ff5f57; }
+.dot--yellow { background: #fdbc2e; }
+.dot--green { background: #28c841; }
+
+.window__title {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.window__body {
+  padding: 20px;
+}
+
+.desktop {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 16px;
+}
+
+.desktop__tile {
+  background: rgba(94, 163, 255, 0.08);
+  border: 1px solid rgba(94, 163, 255, 0.2);
+  border-radius: 12px;
+  padding: 16px;
+  display: grid;
+  place-items: center;
+  gap: 10px;
+  min-height: 120px;
+  text-align: center;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.emoji {
+  font-size: 1.8rem;
+}
+
+main {
+  margin-top: 64px;
+  display: grid;
+  gap: 32px;
+  position: relative;
+  z-index: 1;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: var(--shadow);
+}
+
+.panel--alt {
+  background: var(--panel-alt);
+}
+
+.panel__header {
+  margin-bottom: 18px;
+}
+
+.panel__header h2 {
+  font-size: 1.6rem;
+  margin-bottom: 6px;
+}
+
+.panel__header p {
+  color: var(--muted);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: var(--card);
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.card__icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(94, 163, 255, 0.15);
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+}
+
+.card h3 {
+  margin-bottom: 8px;
+}
+
+.card p {
+  color: var(--muted);
+}
+
+.startmenu {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 18px;
+}
+
+.startmenu__grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.startmenu__grid li {
+  padding: 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  text-align: center;
+  font-weight: 600;
+}
+
+.recents {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.download {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.footer {
+  margin-top: 32px;
+  text-align: center;
+  color: var(--muted);
+  z-index: 1;
+  position: relative;
+}
+
+.footer__brand {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: var(--text);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 32px 20px 64px;
+  }
+
+  .startmenu {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- create a NuttyOS landing page with hero, features, and download sections
- add styling to deliver a Windows-inspired desktop and start menu feel

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d740bbbc8320970400a42fb2db3d)