### PR TITLE
Add NuttyOS Windows-inspired landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,217 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>NuttyOS · Windows-inspired experience</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="sky"></div>
+  <header class="topbar">
+    <div class="brand">
+      <div class="tile"></div>
+      <span class="logo-text">NuttyOS</span>
+      <span class="tag">Windows-inspired</span>
+    </div>
+    <nav>
+      <a href="#features">Features</a>
+      <a href="#desktop">Desktop</a>
+      <a href="#download">Download</a>
+    </nav>
+    <button class="pill ghost" id="startToggle">Start</button>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="hero-content">
+        <p class="eyebrow">Productivity-first shell</p>
+        <h1>Meet NuttyOS</h1>
+        <p class="lede">A sleek, Windows-inspired workspace that blends familiar navigation with a modern, buttery-smooth UI. Everything you need is one click away.</p>
+        <div class="actions">
+          <a class="pill primary" href="#download">Download preview</a>
+          <button class="pill ghost" id="openDesktop">Peek at the desktop</button>
+        </div>
+        <div class="status">
+          <div class="dot"></div>
+          <span>Build 2411 • Fast boot • Fluent panels</span>
+        </div>
+      </div>
+      <div class="glass desktop-preview" id="desktop">
+        <div class="title-bar">
+          <div class="lights">
+            <span class="light red"></span>
+            <span class="light yellow"></span>
+            <span class="light green"></span>
+          </div>
+          <span class="title">Desktop · NuttyOS</span>
+        </div>
+        <div class="desktop-grid">
+          <div class="tile" data-window="files">
+            <div class="icon folder"></div>
+            <span>Files</span>
+          </div>
+          <div class="tile" data-window="browser">
+            <div class="icon browser"></div>
+            <span>EdgeSpace</span>
+          </div>
+          <div class="tile" data-window="terminal">
+            <div class="icon terminal"></div>
+            <span>Terminal</span>
+          </div>
+          <div class="tile" data-window="store">
+            <div class="icon store"></div>
+            <span>Store</span>
+          </div>
+          <div class="tile" data-window="notes">
+            <div class="icon note"></div>
+            <span>Sticky Notes</span>
+          </div>
+          <div class="tile" data-window="clock">
+            <div class="icon clock"></div>
+            <span>Clock</span>
+          </div>
+        </div>
+        <div class="taskbar">
+          <div class="start" id="startToggle2">❖</div>
+          <div class="taskbar-app active">Files</div>
+          <div class="taskbar-app">EdgeSpace</div>
+          <div class="taskbar-app">Store</div>
+          <div class="tray">
+            <span class="pill tiny">Wi‑Fi</span>
+            <span class="pill tiny">98%</span>
+            <span class="pill tiny" id="clock">12:45</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="features" class="section">
+      <div class="section-header">
+        <p class="eyebrow">Why NuttyOS</p>
+        <h2>Familiar, but better</h2>
+        <p class="lede">From the Start menu to snap layouts, NuttyOS keeps the things you love about Windows while leveling up speed, clarity, and focus.</p>
+      </div>
+      <div class="grid features-grid">
+        <article class="card">
+          <div class="icon badge">⚡</div>
+          <h3>Instant boot & resume</h3>
+          <p>Lean boot pipeline delivers a responsive desktop in under 5 seconds with hybrid sleep for near-instant wake.</p>
+        </article>
+        <article class="card">
+          <div class="icon badge">🪟</div>
+          <h3>Fluent panels</h3>
+          <p>Glassmorphic shells, adaptive blur, and subtle depth cues give every window the polish of a flagship OS.</p>
+        </article>
+        <article class="card">
+          <div class="icon badge">🧩</div>
+          <h3>Seamless compatibility</h3>
+          <p>Runs classic Win apps alongside new PWA-style experiences without sacrificing stability or battery life.</p>
+        </article>
+        <article class="card">
+          <div class="icon badge">🗂️</div>
+          <h3>Snap flow</h3>
+          <p>Drag to corners for intelligent tiling, create saved layouts for workflows, and jump back with one shortcut.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section duo">
+      <div class="card glass story">
+        <p class="eyebrow">Designed for creators</p>
+        <h2>Keep the Start experience you know—just faster.</h2>
+        <p class="lede">Pinned apps, quick search, and smart recommendations live in a familiar Start surface with richer shortcuts and live system stats.</p>
+        <div class="quick-list">
+          <span class="pill">Pinned</span>
+          <span class="pill">Recent</span>
+          <span class="pill">Workspaces</span>
+          <span class="pill">System</span>
+        </div>
+      </div>
+      <div class="card glass start-menu" id="startMenu">
+        <div class="start-header">
+          <div>
+            <p class="eyebrow">Start</p>
+            <h3>Everything in one place</h3>
+          </div>
+          <button class="pill tiny ghost" id="closeStart">✕</button>
+        </div>
+        <div class="pinned">
+          <div class="pin">Files</div>
+          <div class="pin">EdgeSpace</div>
+          <div class="pin">Mail</div>
+          <div class="pin">Photos</div>
+          <div class="pin">Store</div>
+          <div class="pin">Terminal</div>
+        </div>
+        <div class="recommendations">
+          <p class="eyebrow">Recommended</p>
+          <ul>
+            <li><span>Project Walnut</span><small>Edited 3m ago</small></li>
+            <li><span>Design kit.figma</span><small>Opened 17m ago</small></li>
+            <li><span>Setup wizard</span><small>New install</small></li>
+          </ul>
+        </div>
+        <div class="system-row">
+          <div class="pill">Settings</div>
+          <div class="pill">Profile</div>
+          <div class="pill">Power ▾</div>
+        </div>
+      </div>
+    </section>
+
+    <section id="download" class="section">
+      <div class="section-header">
+        <p class="eyebrow">Get started</p>
+        <h2>Download NuttyOS Preview</h2>
+        <p class="lede">Grab the latest ISO and pair it with the NuttyOS companion app for updates and recovery tools.</p>
+      </div>
+      <div class="grid steps">
+        <div class="step">
+          <span class="step-number">1</span>
+          <div>
+            <h3>Download ISO</h3>
+            <p>Get the 64-bit image optimized for secure boot and modern hardware.</p>
+          </div>
+        </div>
+        <div class="step">
+          <span class="step-number">2</span>
+          <div>
+            <h3>Create installer</h3>
+            <p>Flash to USB with the NuttyOS Maker, then boot with UEFI enabled.</p>
+          </div>
+        </div>
+        <div class="step">
+          <span class="step-number">3</span>
+          <div>
+            <h3>Sign in & sync</h3>
+            <p>Restore your apps, layouts, and theme from the cloud in under 5 minutes.</p>
+          </div>
+        </div>
+      </div>
+      <div class="cta">
+        <a class="pill primary" href="#">Download (3.2 GB)</a>
+        <a class="pill ghost" href="#">View release notes</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="brand">
+      <div class="tile"></div>
+      <span class="logo-text">NuttyOS</span>
+    </div>
+    <p>Built for people who want Windows ease with next-gen speed.</p>
+    <div class="foot-links">
+      <a href="#">Privacy</a>
+      <a href="#">Support</a>
+      <a href="#">Status</a>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,36 @@
+const startMenu = document.getElementById('startMenu');
+const startToggle = document.getElementById('startToggle');
+const startToggle2 = document.getElementById('startToggle2');
+const closeStart = document.getElementById('closeStart');
+const desktop = document.getElementById('desktop');
+const openDesktop = document.getElementById('openDesktop');
+const clockLabel = document.getElementById('clock');
+
+function toggleStart(show) {
+  const isOpen = startMenu.classList.contains('open');
+  const shouldShow = show !== undefined ? show : !isOpen;
+  startMenu.classList.toggle('open', shouldShow);
+  startMenu.style.transform = shouldShow ? 'translateY(0)' : 'translateY(-6px)';
+  startMenu.style.opacity = shouldShow ? '1' : '0.2';
+}
+
+function openDesktopArea() {
+  desktop.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  desktop.classList.add('pulse');
+  setTimeout(() => desktop.classList.remove('pulse'), 1000);
+}
+
+function updateClock() {
+  const now = new Date();
+  const time = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  clockLabel.textContent = time;
+}
+
+[startToggle, startToggle2]?.forEach(btn => btn.addEventListener('click', () => toggleStart()));
+closeStart?.addEventListener('click', () => toggleStart(false));
+openDesktop?.addEventListener('click', openDesktopArea);
+setInterval(updateClock, 1000);
+updateClock();
+
+toggleStart(true);
+setTimeout(() => toggleStart(false), 1600);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,150 @@
+:root {
+  --bg: #050b18;
+  --panel: rgba(255, 255, 255, 0.08);
+  --glass: rgba(255, 255, 255, 0.12);
+  --border: rgba(255, 255, 255, 0.15);
+  --accent: #3aa0ff;
+  --accent-2: #6ee7ff;
+  --text: #e9f2ff;
+  --muted: #c5d6f7;
+  --shadow: 0 25px 70px rgba(0, 0, 0, 0.35);
+  --radius: 18px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, rgba(58, 160, 255, 0.12), transparent 35%),
+              radial-gradient(circle at 80% 0%, rgba(110, 231, 255, 0.1), transparent 40%),
+              #050b18;
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.6;
+}
+
+.sky {
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(58, 160, 255, 0.25), rgba(110, 231, 255, 0.05), rgba(5, 11, 24, 0.5));
+  filter: blur(80px);
+  z-index: 0;
+  pointer-events: none;
+}
+
+main { position: relative; z-index: 1; padding: 120px clamp(20px, 6vw, 80px) 80px; }
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px clamp(20px, 6vw, 80px);
+  background: rgba(5, 11, 24, 0.7);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand { display: flex; gap: 10px; align-items: center; font-weight: 700; letter-spacing: 0.2px; }
+.logo-text { font-size: 18px; }
+.tile { width: 18px; height: 18px; background: linear-gradient(135deg, var(--accent), var(--accent-2)); border-radius: 4px; box-shadow: 0 4px 12px rgba(58, 160, 255, 0.5); }
+.tag { font-size: 12px; color: var(--muted); padding: 4px 10px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.04); }
+
+nav { display: flex; gap: 14px; }
+nav a { color: var(--muted); text-decoration: none; font-weight: 500; padding: 8px 12px; border-radius: 10px; }
+nav a:hover { background: var(--panel); color: var(--text); }
+
+.hero { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 30px; align-items: center; }
+.hero-content h1 { font-size: clamp(36px, 6vw, 60px); margin: 10px 0; }
+.hero-content .lede { max-width: 560px; color: var(--muted); }
+.eyebrow { text-transform: uppercase; letter-spacing: 1px; font-size: 12px; color: var(--accent-2); margin: 0 0 8px; }
+.lede { font-size: 16px; }
+
+.pill { display: inline-flex; align-items: center; justify-content: center; gap: 8px; border-radius: 999px; padding: 12px 18px; font-weight: 600; text-decoration: none; border: 1px solid transparent; cursor: pointer; transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease; }
+.pill.primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #041026; box-shadow: 0 15px 40px rgba(58, 160, 255, 0.35); }
+.pill.ghost { background: rgba(255,255,255,0.05); color: var(--text); border-color: var(--border); }
+.pill:hover { transform: translateY(-1px); }
+.pill:active { transform: translateY(0); }
+.pill.tiny { padding: 8px 12px; font-size: 12px; }
+
+.actions { display: flex; gap: 12px; flex-wrap: wrap; margin: 16px 0 12px; }
+.status { display: inline-flex; gap: 8px; align-items: center; color: var(--muted); }
+.status .dot { width: 8px; height: 8px; border-radius: 50%; background: #5df4a6; box-shadow: 0 0 0 6px rgba(93, 244, 166, 0.2); }
+
+.glass { background: var(--glass); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); backdrop-filter: blur(20px); }
+.desktop-preview { padding: 16px; min-height: 420px; position: relative; overflow: hidden; }
+.title-bar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; color: var(--muted); font-size: 14px; }
+.lights { display: flex; gap: 8px; }
+.light { width: 10px; height: 10px; border-radius: 50%; display: block; opacity: 0.8; }
+.light.red { background: #ff6b6b; }
+.light.yellow { background: #ffd166; }
+.light.green { background: #3dd598; }
+.desktop-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 12px; }
+.desktop-grid .tile { padding: 14px; border: 1px solid transparent; border-radius: 12px; cursor: pointer; text-align: center; transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease; }
+.desktop-grid .tile:hover { transform: translateY(-4px); border-color: var(--accent); background: rgba(58, 160, 255, 0.08); }
+.desktop-grid span { display: block; margin-top: 10px; color: var(--muted); font-size: 14px; }
+.icon { width: 42px; height: 42px; margin: 0 auto; border-radius: 12px; background: linear-gradient(135deg, rgba(58, 160, 255, 0.6), rgba(110, 231, 255, 0.4)); box-shadow: 0 10px 25px rgba(58, 160, 255, 0.25); position: relative; }
+.icon.folder::after { content: ""; position: absolute; inset: 10px 8px 8px; border-radius: 6px; background: rgba(255, 255, 255, 0.35); }
+.icon.browser::after { content: "🌐"; position: absolute; inset: 0; display: grid; place-items: center; font-size: 18px; }
+.icon.terminal::after { content: ">_"; position: absolute; inset: 0; display: grid; place-items: center; font-weight: 700; color: #031025; }
+.icon.store::after { content: "🛍️"; position: absolute; inset: 0; display: grid; place-items: center; font-size: 18px; }
+.icon.note::after { content: "✏️"; position: absolute; inset: 0; display: grid; place-items: center; font-size: 18px; }
+.icon.clock::after { content: "⏰"; position: absolute; inset: 0; display: grid; place-items: center; font-size: 18px; }
+
+.taskbar { margin-top: 18px; background: rgba(255,255,255,0.05); border: 1px solid var(--border); border-radius: 12px; padding: 10px; display: flex; gap: 10px; align-items: center; justify-content: space-between; }
+.taskbar .start { width: 40px; height: 40px; border-radius: 10px; display: grid; place-items: center; background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #041026; font-weight: 800; cursor: pointer; box-shadow: 0 10px 25px rgba(58, 160, 255, 0.3); }
+.taskbar-app { background: rgba(255,255,255,0.06); padding: 10px 14px; border-radius: 12px; border: 1px solid var(--border); color: var(--muted); }
+.taskbar-app.active { border-color: var(--accent); color: var(--text); }
+.tray { display: flex; gap: 8px; margin-left: auto; }
+
+.section { margin-top: 90px; }
+.section-header h2 { margin: 6px 0 10px; font-size: clamp(26px, 4vw, 38px); }
+.section-header .lede { max-width: 780px; }
+.grid { display: grid; gap: 16px; }
+.features-grid { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+.card { padding: 22px; border-radius: var(--radius); border: 1px solid var(--border); background: rgba(255,255,255,0.05); }
+.card h3 { margin: 12px 0 8px; }
+.card p { color: var(--muted); }
+.badge { width: 42px; height: 42px; border-radius: 12px; background: linear-gradient(135deg, rgba(58,160,255,0.25), rgba(110,231,255,0.2)); display: grid; place-items: center; font-size: 18px; }
+
+.duo { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 18px; align-items: stretch; }
+.story { min-height: 100%; }
+.quick-list { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 14px; }
+
+.start-menu { position: relative; overflow: hidden; background: linear-gradient(160deg, rgba(58,160,255,0.12), rgba(110,231,255,0.08), rgba(255,255,255,0.04)); transition: opacity 0.3s ease, transform 0.3s ease; opacity: 0.2; transform: translateY(-6px); }
+.start-menu.open { opacity: 1; transform: translateY(0); }
+.pulse { box-shadow: 0 0 0 0 rgba(58, 160, 255, 0.4); animation: pulse 1s ease forwards; }
+.pulse .title-bar { color: #fff; }
+.start-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+.start-header h3 { margin: 4px 0 0; }
+.pinned { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; margin: 12px 0; }
+.pin { background: rgba(255,255,255,0.06); border: 1px solid var(--border); padding: 12px; border-radius: 12px; text-align: center; color: var(--text); }
+.recommendations ul { list-style: none; padding: 0; margin: 8px 0; display: grid; gap: 8px; }
+.recommendations li { background: rgba(255,255,255,0.05); border: 1px solid var(--border); padding: 10px 12px; border-radius: 10px; display: flex; justify-content: space-between; color: var(--muted); }
+.system-row { display: flex; gap: 10px; margin-top: 12px; flex-wrap: wrap; }
+
+.steps { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 18px; margin-top: 16px; }
+.step { display: grid; grid-template-columns: auto 1fr; gap: 12px; padding: 18px; background: rgba(255,255,255,0.05); border: 1px solid var(--border); border-radius: var(--radius); align-items: center; }
+.step-number { width: 38px; height: 38px; border-radius: 12px; display: grid; place-items: center; background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #041026; font-weight: 700; }
+
+.cta { margin-top: 16px; display: flex; gap: 12px; flex-wrap: wrap; }
+
+footer { padding: 32px clamp(20px, 6vw, 80px); border-top: 1px solid var(--border); background: rgba(5,11,24,0.8); backdrop-filter: blur(14px); color: var(--muted); display: flex; gap: 16px; flex-wrap: wrap; align-items: center; justify-content: space-between; }
+.foot-links { display: flex; gap: 14px; }
+.foot-links a { color: var(--muted); text-decoration: none; }
+
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(58, 160, 255, 0.4); }
+  70% { box-shadow: 0 0 0 18px rgba(58, 160, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(58, 160, 255, 0); }
+}
+
+@media (max-width: 720px) {
+  main { padding-top: 90px; }
+  .topbar { position: fixed; width: 100%; left: 0; right: 0; }
+  .taskbar { flex-wrap: wrap; }
+  .tray { margin-left: 0; }
+}


### PR DESCRIPTION
## Summary
- create a NuttyOS landing page showcasing Windows-inspired UI and desktop preview
- style the experience with glassmorphic panels, tiles, and responsive layout
- add lightweight interactivity for Start menu toggle, desktop focus, and live clock

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d740bbbc8320970400a42fb2db3d)