### PR TITLE
Create NuttyOS Windows-inspired web desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NuttyOS | Web Desktop</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="sky"></div>
+  <main class="desktop">
+    <header class="info-card">
+      <div>
+        <p class="eyebrow">WELCOME TO</p>
+        <h1>NuttyOS</h1>
+        <p class="lede">A playful Windows-inspired web desktop built just for you.</p>
+      </div>
+      <div class="pill">Beta</div>
+    </header>
+
+    <section class="icon-grid" aria-label="Desktop icons">
+      <button class="icon" data-app="explorer">
+        <span class="icon-emoji">🗂️</span>
+        <span>File Explorer</span>
+      </button>
+      <button class="icon" data-app="browser">
+        <span class="icon-emoji">🌐</span>
+        <span>Nutty Browser</span>
+      </button>
+      <button class="icon" data-app="notes">
+        <span class="icon-emoji">📝</span>
+        <span>Sticky Notes</span>
+      </button>
+      <button class="icon" data-app="gallery">
+        <span class="icon-emoji">🖼️</span>
+        <span>Gallery</span>
+      </button>
+    </section>
+  </main>
+
+  <div class="start-menu" id="start-menu" aria-hidden="true">
+    <div class="start-header">
+      <div class="start-logo">N</div>
+      <div>
+        <p class="eyebrow">NuttyOS</p>
+        <p class="start-title">Quick launch</p>
+      </div>
+    </div>
+    <div class="start-links">
+      <button data-app="explorer">📁 Open files</button>
+      <button data-app="browser">🧭 Launch Nutty Browser</button>
+      <button data-app="notes">🧠 Open notes</button>
+      <button data-app="gallery">🌄 View gallery</button>
+    </div>
+    <p class="start-foot">Tip: double-click the desktop icons to open windows.</p>
+  </div>
+
+  <div class="window" id="app-window" hidden>
+    <div class="window-bar">
+      <div class="window-title" id="window-title">NuttyOS</div>
+      <button class="close" id="close-window" aria-label="Close window">✕</button>
+    </div>
+    <div class="window-body" id="window-body"></div>
+  </div>
+
+  <footer class="taskbar" aria-label="Taskbar">
+    <button class="start" id="start-button" aria-controls="start-menu">
+      <span class="start-icon">⊞</span>
+      <span>NuttyOS</span>
+    </button>
+    <div class="taskbar-pins">
+      <span class="pin">🗂️</span>
+      <span class="pin">🌐</span>
+      <span class="pin">📝</span>
+      <span class="pin">⚙️</span>
+    </div>
+    <div class="taskbar-clock" id="taskbar-clock"></div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,110 @@
+const startButton = document.getElementById('start-button');
+const startMenu = document.getElementById('start-menu');
+const appWindow = document.getElementById('app-window');
+const windowTitle = document.getElementById('window-title');
+const windowBody = document.getElementById('window-body');
+const closeWindow = document.getElementById('close-window');
+const clock = document.getElementById('taskbar-clock');
+
+const appContent = {
+  explorer: {
+    title: 'Nutty Explorer',
+    body: `
+      <h2>Files &amp; Folders</h2>
+      <p>NuttyOS keeps your essentials close. Here are a few quick links to explore:</p>
+      <ul>
+        <li>📂 Documents — launch product briefs, scripts, and ideas.</li>
+        <li>📦 Downloads — stash for prototypes and experiments.</li>
+        <li>☁️ Cloud drive — sync your files wherever NuttyOS runs.</li>
+      </ul>
+    `,
+  },
+  browser: {
+    title: 'Nutty Browser',
+    body: `
+      <h2>Nutty Browser</h2>
+      <p>A minimal browsing shell that mirrors the feel of Windows web views.</p>
+      <ul>
+        <li>Type <strong>nuttyos.dev</strong> to discover more apps.</li>
+        <li>Pin your favorite tools to the taskbar for fast access.</li>
+        <li>Built-in focus mode for clean, distraction-free reading.</li>
+      </ul>
+    `,
+  },
+  notes: {
+    title: 'Sticky Notes',
+    body: `
+      <h2>Sticky Notes</h2>
+      <p>Capture ideas in one click. Your recent notes stay pinned here:</p>
+      <ul>
+        <li>NuttyOS launch checklist</li>
+        <li>Design tweaks for the glassmorphic taskbar</li>
+        <li>Keyboard shortcuts to ship with the next build</li>
+      </ul>
+    `,
+  },
+  gallery: {
+    title: 'Gallery',
+    body: `
+      <h2>Wallpaper Gallery</h2>
+      <p>Swap backgrounds to change your vibe:</p>
+      <ul>
+        <li>🌅 Sunrise neon</li>
+        <li>🌌 Midnight gradients</li>
+        <li>🌿 Calm forest hues</li>
+      </ul>
+    `,
+  },
+};
+
+function toggleStartMenu(forceClose = false) {
+  const shouldOpen = !forceClose && !startMenu.classList.contains('active');
+  startMenu.classList.toggle('active', shouldOpen);
+  startMenu.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+}
+
+function openApp(appKey) {
+  const app = appContent[appKey];
+  if (!app) return;
+  windowTitle.textContent = app.title;
+  windowBody.innerHTML = app.body;
+  appWindow.hidden = false;
+  appWindow.focus();
+  toggleStartMenu(true);
+}
+
+function closeApp() {
+  appWindow.hidden = true;
+}
+
+function updateClock() {
+  const now = new Date();
+  const options = { hour: '2-digit', minute: '2-digit' };
+  clock.textContent = now.toLocaleTimeString([], options);
+}
+
+startButton.addEventListener('click', () => toggleStartMenu());
+closeWindow.addEventListener('click', closeApp);
+clock && updateClock();
+setInterval(updateClock, 30 * 1000);
+
+document.querySelectorAll('[data-app]').forEach((el) => {
+  el.addEventListener('click', (event) => {
+    // Prevent duplicate opens when the click is part of a double-click gesture.
+    if (event.detail > 1) return;
+    openApp(el.dataset.app);
+  });
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    toggleStartMenu(true);
+    closeApp();
+  }
+});
+
+document.addEventListener('click', (event) => {
+  if (!startMenu.contains(event.target) && !startButton.contains(event.target)) {
+    toggleStartMenu(true);
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,324 @@
+:root {
+  --bg: #0b1526;
+  --panel: rgba(10, 16, 26, 0.65);
+  --accent: #7cd2ff;
+  --accent-2: #9c7cff;
+  --text: #e7f0ff;
+  --muted: #9db0c4;
+  --glass: rgba(255, 255, 255, 0.08);
+  --border: rgba(255, 255, 255, 0.12);
+  --shadow: 0 20px 70px rgba(0, 0, 0, 0.45);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  background: radial-gradient(circle at 15% 20%, #123, transparent 35%),
+    radial-gradient(circle at 80% 0%, #183460, transparent 35%),
+    radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.04), transparent 50%),
+    #0a1221;
+  overflow: hidden;
+}
+
+.sky {
+  position: fixed;
+  inset: -5%;
+  background: radial-gradient(1200px at 30% 20%, rgba(124, 210, 255, 0.18), transparent 50%),
+    radial-gradient(900px at 75% 15%, rgba(156, 124, 255, 0.15), transparent 55%);
+  filter: blur(60px);
+  z-index: 0;
+}
+
+.desktop {
+  position: relative;
+  z-index: 1;
+  min-height: calc(100vh - 64px);
+  padding: 48px clamp(16px, 6vw, 64px) 90px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 28px;
+}
+
+.info-card {
+  background: linear-gradient(135deg, rgba(124, 210, 255, 0.18), rgba(156, 124, 255, 0.18)),
+    var(--panel);
+  border: 1px solid var(--border);
+  padding: 20px 24px;
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  backdrop-filter: blur(16px);
+}
+
+.info-card h1 {
+  margin: 4px 0 6px;
+  font-size: clamp(28px, 4vw, 36px);
+  letter-spacing: -0.5px;
+}
+
+.lede {
+  margin: 0;
+  color: var(--muted);
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.pill {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border);
+  font-weight: 700;
+}
+
+.icon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  align-content: start;
+}
+
+.icon {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px;
+  text-align: left;
+  color: var(--text);
+  cursor: pointer;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+  backdrop-filter: blur(10px);
+}
+
+.icon:hover {
+  transform: translateY(-2px);
+  border-color: rgba(124, 210, 255, 0.7);
+  background: rgba(14, 24, 40, 0.85);
+}
+
+.icon:active {
+  transform: translateY(0);
+}
+
+.icon-emoji {
+  font-size: 28px;
+}
+
+.start-menu {
+  position: fixed;
+  bottom: 74px;
+  left: 24px;
+  width: min(320px, 90vw);
+  background: rgba(7, 14, 24, 0.9);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 16px;
+  backdrop-filter: blur(18px);
+  transform: translateY(16px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+  z-index: 3;
+}
+
+.start-menu.active {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.start-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+
+.start-logo {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #0c101c;
+  font-weight: 800;
+  font-size: 16px;
+}
+
+.start-title {
+  margin: 2px 0 0;
+  font-weight: 700;
+}
+
+.start-links {
+  display: grid;
+  gap: 8px;
+}
+
+.start-links button {
+  text-align: left;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.start-links button:hover {
+  border-color: rgba(124, 210, 255, 0.6);
+}
+
+.start-foot {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.window {
+  position: fixed;
+  inset: 50px 50px 120px 50px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(4, 8, 16, 0.92);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
+  display: grid;
+  grid-template-rows: auto 1fr;
+  z-index: 2;
+}
+
+.window-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(90deg, rgba(124, 210, 255, 0.08), rgba(156, 124, 255, 0.08));
+}
+
+.window-title {
+  font-weight: 700;
+}
+
+.close {
+  border: 0;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.window-body {
+  padding: 16px;
+  overflow: auto;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.window-body h2 {
+  color: var(--text);
+  margin-top: 0;
+}
+
+.window-body ul {
+  padding-left: 18px;
+}
+
+.taskbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  display: grid;
+  grid-template-columns: 200px 1fr 200px;
+  align-items: center;
+  padding: 0 18px;
+  background: rgba(6, 12, 20, 0.9);
+  border-top: 1px solid var(--border);
+  backdrop-filter: blur(14px);
+  z-index: 2;
+}
+
+.start {
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.start-icon {
+  font-size: 18px;
+}
+
+.taskbar-pins {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+}
+
+.pin {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.taskbar-clock {
+  justify-self: end;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 768px) {
+  .window {
+    inset: 24px 16px 96px 16px;
+  }
+
+  .taskbar {
+    grid-template-columns: 1fr 1fr;
+    height: auto;
+    gap: 12px;
+    padding: 12px 16px;
+  }
+
+  .taskbar-clock {
+    justify-self: start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a NuttyOS landing page with Windows-style desktop, icons, and start menu
- style the experience with glassmorphic theme, taskbar, and responsive layout
- wire up interactions for opening app windows, toggling the start menu, and showing a live clock

## Testing
- Not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d740bbbc8320970400a42fb2db3d)